### PR TITLE
ML workloads: require plaintext model + test data; document the security-vs-accuracy sweep

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -157,6 +157,17 @@ structure already in place:
    test data. This becomes the ground truth that every subsequent version is
    tested against.
 
+   **Firm requirement for machine-learning workloads:** the user must bring a
+   complete plaintext implementation of the model AND a representative test
+   set with expected outputs before any FHE design work proceeds. This is not
+   optional. Every FHE design decision downstream — Chebyshev approximation
+   degree, scaling modulus size (q_i), multiplicative depth, ring dimension —
+   trades accuracy against security and performance, and those trades can
+   only be evaluated against END-TO-END MODEL ACCURACY on real test data, not
+   against per-operation error bounds. Without the plaintext model and test
+   set there is no way to tell whether a cheaper parameter choice costs 0.1%
+   accuracy or destroys the model.
+
 2. Separate client-side and server-side responsibilities cleanly. The server
    must complete its work in one pass — no round trips, no branching on
    intermediate values.
@@ -373,6 +384,18 @@ compute the total bytes:
 
 Present these estimates to the user so they can assess whether the
 deployment is practical for their network and memory constraints.
+
+**The security-vs-accuracy sweep.** For ML workloads, treat parameter
+selection as an empirical optimization over the test set from Stage 3: sweep
+(approximation degree, q_i, depth, N) and measure end-to-end model accuracy at
+each point against the plaintext reference. The interplay is mechanical —
+higher approximation degree buys accuracy but costs depth; depth and q_i set
+log2(Q) = first_mod + depth x q_i; log2(Q) and the security target set the
+minimum ring dimension N; N sets performance. When implementing in the nb DSL
+(Stage 7 Track A), the compiler surfaces this frontier at compile time
+(chebyshev depth charging and a params note mapping logQ to the minimum N per
+security level), and the generated cleartext reference twins measure each
+sweep point's accuracy without re-running encryption.
 
 **For reference on parameter choices in practice:** The example applications in
 the references directory show concrete parameter selections with rationale.

--- a/references/implementing-with-nb-dsl.md
+++ b/references/implementing-with-nb-dsl.md
@@ -29,7 +29,8 @@ to transcribe the design:
 | What crosses the wire (1, 8) | `wire` type declarations — the compiler generates all serialization; a stage's `reads(...)`/`writes(...)` clauses are a machine-checked message-flow spec |
 | Who encrypts / packing legality (1, 5) | Expressed in *which stage does the encrypting*. Single encryptor → one `@client` stage packs records across slots. Independent encryptors → each owner's data is its own ciphertext; never pack across owners (the DSL does not yet check this — enforce it by design review) |
 | Scheme selection (4) | `scheme CKKS { ... }` block. **The DSL is CKKS-only today** — a BFV/BGV design must use Track B |
-| Depth budget (5, 6) | `depth:` in the scheme block; per-instance via `scheme.override(depth: inst.depth)`. The compiler **errors** when the statically tracked multiplication chain exceeds the budget (a sound lower bound), and warns when the budget is heavily over-provisioned — the warning stays silent when depth is statically opaque (loops over encrypted ops, `chebyshev`, `*_norelin`, combinators, `extern_call`) |
+| Depth budget (5, 6) | `depth:` in the scheme block; per-instance via `scheme.override(depth: inst.depth)`. The compiler **errors** when the statically tracked multiplication chain exceeds the budget (a sound lower bound) and warns on heavy over-provisioning. `chebyshev` with a literal/const `degree:` is a **modeled subcircuit**: it charges `ceil(log2(degree+1)) + 1` levels into the tracker (59 → 7, 119 → 8, …); non-literal degrees stay depth-opaque |
+| Security ↔ parameters frontier (6) | Compile-time advisor: `nbc check` emits a `note:` computing `logQ ≈ first_mod + depth × q_i` and the minimum ring dimension for the declared security level (HE-standard tables), flagging declared `ring_dim`s below target (warning if no `scheme.override(security:)` dev profile covers them). Use it to trade q_i / depth / approximation degree against N |
 | Ring dimension / slots (6) | `ring_dim` field on the `Instance` struct (applied automatically); `n_slots = ring_dim / 2` for CKKS |
 | Security level (6) | `security:` in the scheme block; `scheme.override(security: not_set)` for toy/dev profiles |
 | Scaling / first modulus (6) | `precision:` (scaling mod size) and `first_mod:` in the scheme block |
@@ -76,6 +77,16 @@ to transcribe the design:
    parse/semantic checks over all examples; the end-to-end target verifies
    numerics. A new example should reach `0 warnings, 0 errors` on
    `nbc.py check`.
+
+5. **ML workloads: ground truth first, then sweep.** Require a full plaintext
+   model implementation and a representative test set (Stage 3 — firm, not
+   advisory). Then run the security-vs-accuracy sweep: vary (Chebyshev
+   `degree:`, `precision:` (q_i), `depth:`, `ring_dim`) and measure
+   end-to-end model accuracy at each point. The compiler's params note shows
+   where each configuration sits on the security frontier; the generated
+   `_ref` reference twins give each sweep point's accuracy (vs. the true
+   nonlinearities) without running encryption; the encrypted pipeline
+   confirms the final choice.
 
 ## Worked design↔implementation pairs
 


### PR DESCRIPTION
Two related additions, companion to the niobium-client approx-subcircuits PR:

1. **Firm Stage 3 requirement for ML**: a complete plaintext model implementation **and** a representative test set with expected outputs are prerequisites, not suggestions. Every parameter trade (Chebyshev degree, q_i, depth, N) is only judgeable by end-to-end model accuracy — per-operation error bounds don't compose.

2. **The security-vs-accuracy sweep (Stage 6 + Track A workflow)**: the mechanical interplay — degree ↔ accuracy ↔ depth; `logQ ≈ first_mod + depth × q_i`; logQ + security target ↔ minimum N; N ↔ performance — documented as an empirical sweep over the test set. The DSL now surfaces the frontier at compile time (`chebyshev` with literal degree charges `ceil(log2(d+1))+1` levels; a params `note:` maps logQ to the minimum ring dimension per security level), and the generated cleartext reference twins measure each sweep point's accuracy without re-running encryption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)