### PR TITLE
Rename the merge job to publish and update action versions

### DIFF
--- a/.github/workflows/publish-fhe-dev-image.yml
+++ b/.github/workflows/publish-fhe-dev-image.yml
@@ -61,13 +61,13 @@ jobs:
       skip: ${{ steps.ref.outputs.skip }}
     steps:
       - name: Checkout (with tags, to resolve the current image version)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -110,7 +110,7 @@ jobs:
 
   # One native build per architecture: build -> smoke test -> push a per-arch tag.
   # The per-arch tags (:<version>-amd64 / :<version>-arm64) are assembled into the
-  # user-facing manifest lists by the `merge` job only after every arch passes.
+  # user-facing manifest lists by the `publish` job only after every arch passes.
   build:
     needs: prep
     if: needs.prep.outputs.skip != 'true'
@@ -138,10 +138,10 @@ jobs:
           df -h /
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -173,13 +173,13 @@ jobs:
 
   # Assemble the two per-arch images into multi-arch manifest lists and publish
   # the user-facing tags. Only runs if BOTH arch builds+smoke tests passed.
-  merge:
+  publish:
     needs: [prep, build]
     if: needs.prep.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
publish says what the job ships (the multi-arch manifest lists) without reading as a git merge. actions/checkout moves to v7 and docker/login-action to v4, clearing the Node 20 deprecation warnings.